### PR TITLE
Removing ember-weakmap due to current browser support

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,11 +1,10 @@
-import Ember from 'ember';
 
 function isEqual(key, a, b) {
   return a === b;
 }
 
 export default function(keys, hook) {
-  let oldValuesMap = new Ember.WeakMap();
+  let oldValuesMap = new WeakMap();
   let isEqualFunc = isEqual;
 
   if (typeof keys === 'object') {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0",
-    "ember-weakmap": "^3.0.0"
+    "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,7 +1279,7 @@ broccoli-writer@~0.1.1:
     quick-temp "^0.1.0"
     rsvp "^3.0.6"
 
-browserslist@^2.1.2, browserslist@^2.2.2:
+browserslist@^2.1.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.1.tgz#02fda29d9a2164b879100126e7b0d0b57e43a7bb"
   dependencies:
@@ -2271,14 +2271,6 @@ ember-try@^0.2.15:
     rimraf "^2.3.2"
     rsvp "^3.0.17"
     semver "^5.1.0"
-
-ember-weakmap@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/ember-weakmap/-/ember-weakmap-3.1.1.tgz#2ae6e0080b5b80cf0d108f7752dc69ea9603dbd7"
-  dependencies:
-    browserslist "^2.2.2"
-    debug "^3.1.0"
-    ember-cli-babel "^6.3.0"
 
 encodeurl@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
[Current browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#Browser_compatibility) is quite good for [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#Browser_compatibility). This PR removes the use of the `ember-weakmap` polyfill. 