### PR TITLE
Add the ability to use Ember's brace expansion with the keys

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,3 +1,4 @@
+import { expandProperties } from '@ember/object/computed';
 
 function isEqual(key, a, b) {
   return a === b;
@@ -36,7 +37,10 @@ export default function(keys, hook) {
 
     oldValues = oldValuesMap.get(this);
 
-    keys.forEach(key => {
+    const expandedKeys = [];
+    keys.forEach(key => expandProperties(key, expandedKey => expandedKeys.push(expandedKey)));
+
+    expandedKeys.forEach(key => {
       let value = this.get(key);
       if (!isEqualFunc(key, oldValues[key], value)) {
         changedAttrs[key] = [oldValues[key], value];

--- a/yarn.lock
+++ b/yarn.lock
@@ -8097,9 +8097,9 @@ tmp@^0.0.29:
     os-tmpdir "~1.0.1"
 
 tmpl@1.0.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
-  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
+  integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
 to-array@0.1.4:
   version "0.1.4"


### PR DESCRIPTION
Brace expansion will be familiar to anyone who has worked with Ember's computed properties, and it's something I've been wanting to use with `ember-diff-attrs` for a while.

For those unfamiliar with brace exapansion, it allows developers to specify related property names grouped together in curly braces, to avoid having to specify the parent path multiple times.

### Before:
```javascript
didReceiveAttrs: diffAttrs('user.forename', 'user.age', 'admin.surname', 'admin.email', 'admin.age', function(changedAttrs) {
  ...
})
```
### After:
```javascript
didReceiveAttrs: diffAttrs('user.{forename,age}', 'admin.{surname,email,age}', function(changedAttrs) {
  ...
})
```
